### PR TITLE
Additional behaviour combinations in PS1Profiler

### DIFF
--- a/tests/results/1954ce6974e8203214c9eb20c2d73bd765e8d5599b9a02b3656845a50f61a634/result.json
+++ b/tests/results/1954ce6974e8203214c9eb20c2d73bd765e8d5599b9a02b3656845a50f61a634/result.json
@@ -168,7 +168,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: Net.WebClient, DownloadString",
+        "body": "Marks: WebClient, DownloadString",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",

--- a/tests/results/35867e49e1c048ad00c9f40c10ec62a2c5e81c3b9b25511ea70fa44501fbe57e/result.json
+++ b/tests/results/35867e49e1c048ad00c9f40c10ec62a2c5e81c3b9b25511ea70fa44501fbe57e/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 2063,
+    "score": 2173,
     "sections": [
       {
         "auto_collapse": false,
@@ -260,6 +260,54 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: Sleeps",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: EncodedCommand",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 100,
+          "score_map": {
+            "Obfuscation": 100
+          },
+          "signatures": {
+            "Obfuscation": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Obfuscation",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: -ExecutionPolicy",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Evasion": 10
+          },
+          "signatures": {
+            "Evasion": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Evasion",
         "zeroize_on_tag_safe": false
       },
       {
@@ -782,6 +830,20 @@
         "heur_id": 3,
         "signatures": [
           "Sleeps"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Obfuscation"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Evasion"
         ]
       },
       {

--- a/tests/results/6db756ef33294db47957b8351d4419dbff3fa7aa508259f419b669eef017fe09/result.json
+++ b/tests/results/6db756ef33294db47957b8351d4419dbff3fa7aa508259f419b669eef017fe09/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1331,
+    "score": 1441,
     "sections": [
       {
         "auto_collapse": false,
@@ -223,7 +223,31 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: [System.Convert]::FromBase64String(",
+        "body": "Marks: Text.Encoding, System.Convert",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 100,
+          "score_map": {
+            "Obfuscation": 100
+          },
+          "signatures": {
+            "Obfuscation": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Obfuscation",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: FromBase64String(",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -315,6 +339,30 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: Imports BitsTransfer",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: env:APPDATA",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Filesystem": 10
+          },
+          "signatures": {
+            "Filesystem": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Filesystem",
         "zeroize_on_tag_safe": false
       },
       {
@@ -412,6 +460,13 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
+          "Obfuscation"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
           "Deobfuscation"
         ]
       },
@@ -434,6 +489,13 @@
         "heur_id": 3,
         "signatures": [
           "Imports BitsTransfer"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Filesystem"
         ]
       },
       {

--- a/tests/results/74a47198fefa10a8ebb88a8b130259e56a5a9fc4302089ac73009742ba5c98dc/result.json
+++ b/tests/results/74a47198fefa10a8ebb88a8b130259e56a5a9fc4302089ac73009742ba5c98dc/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 541,
+    "score": 641,
     "sections": [
       {
         "auto_collapse": false,
@@ -38,7 +38,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: wget",
+        "body": "Marks: TCPClient, wget, Net.Sockets, AcceptTcpClient",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -106,6 +106,30 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: Hidden Window",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: Text.Encoding",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 100,
+          "score_map": {
+            "Obfuscation": 100
+          },
+          "signatures": {
+            "Obfuscation": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Obfuscation",
         "zeroize_on_tag_safe": false
       },
       {
@@ -197,6 +221,13 @@
         "heur_id": 3,
         "signatures": [
           "Hidden Window"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Obfuscation"
         ]
       },
       {

--- a/tests/results/786d3f381553f08829ac453963596c2e71c4ad9ea25bb6f097c918fc4ff9d8fb/result.json
+++ b/tests/results/786d3f381553f08829ac453963596c2e71c4ad9ea25bb6f097c918fc4ff9d8fb/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 151,
+    "score": 261,
     "sections": [
       {
         "auto_collapse": false,
@@ -66,7 +66,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: Convert, FromBase64String, Text.Encoding, Compression.CompressionMode]::Decompress, IO.Compression.DeflateStream, IO.MemoryStream",
+        "body": "Marks: Convert, FromBase64String, Text.Encoding, Compression.CompressionMode, IO.Compression.DeflateStream, IO.MemoryStream",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -90,7 +90,31 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: [Convert]::FromBase64String(",
+        "body": "Marks: Text.Encoding, System.Convert",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 100,
+          "score_map": {
+            "Obfuscation": 100
+          },
+          "signatures": {
+            "Obfuscation": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Obfuscation",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: FromBase64String(",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -158,6 +182,30 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: Byte Usage",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: IO.File",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Filesystem": 10
+          },
+          "signatures": {
+            "Filesystem": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Filesystem",
         "zeroize_on_tag_safe": false
       },
       {
@@ -268,6 +316,13 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
+          "Obfuscation"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
           "Deobfuscation"
         ]
       },
@@ -283,6 +338,13 @@
         "heur_id": 3,
         "signatures": [
           "Byte Usage"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Filesystem"
         ]
       }
     ],

--- a/tests/results/8a14efe45843057c5d7a8ec7258c3bb6757a7b8ce5831c98873e0242041b8de8/result.json
+++ b/tests/results/8a14efe45843057c5d7a8ec7258c3bb6757a7b8ce5831c98873e0242041b8de8/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 140,
+    "score": 150,
     "sections": [
       {
         "auto_collapse": false,
@@ -157,6 +157,30 @@
         "tags": {},
         "title_text": "Signature: Byte Usage",
         "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: env:APPDATA, Remove-Item, New-Item, IO.File",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Filesystem": 10
+          },
+          "signatures": {
+            "Filesystem": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Filesystem",
+        "zeroize_on_tag_safe": false
       }
     ]
   },
@@ -221,6 +245,13 @@
         "heur_id": 3,
         "signatures": [
           "Byte Usage"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Filesystem"
         ]
       }
     ],

--- a/tests/results/8dcad766215c455f6c70f5e78ebb1776e5e436775cbb7f66f1d5d4ccd217e03a/result.json
+++ b/tests/results/8dcad766215c455f6c70f5e78ebb1776e5e436775cbb7f66f1d5d4ccd217e03a/result.json
@@ -166,7 +166,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: Net.WebClient, DownloadFile",
+        "body": "Marks: WebClient, DownloadFile, host",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",

--- a/tests/results/8f17242fd8a6ffbdda9969e09c04ae54f499ef9768693e29068f41bc54ea4bcd/result.json
+++ b/tests/results/8f17242fd8a6ffbdda9969e09c04ae54f499ef9768693e29068f41bc54ea4bcd/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 230,
+    "score": 240,
     "sections": [
       {
         "auto_collapse": false,
@@ -90,7 +90,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: [Convert]::FromBase64String(",
+        "body": "Marks: FromBase64String(",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -134,6 +134,30 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: Byte Usage",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: IO.File",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Filesystem": 10
+          },
+          "signatures": {
+            "Filesystem": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Filesystem",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -182,6 +206,13 @@
         "heur_id": 3,
         "signatures": [
           "Byte Usage"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Filesystem"
         ]
       }
     ],

--- a/tests/results/958ed6efd9131c1207df57aeae8b5e0635d135e53d51bbf3d2c3ea1e770d6a97/result.json
+++ b/tests/results/958ed6efd9131c1207df57aeae8b5e0635d135e53d51bbf3d2c3ea1e770d6a97/result.json
@@ -187,7 +187,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: Net.WebClient, DownloadFile",
+        "body": "Marks: WebClient, DownloadFile",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",

--- a/tests/results/c4cf9f8de6d0be53e5ba263fe8eeb33c199a21f70004d83e06bbded76dc5f322/result.json
+++ b/tests/results/c4cf9f8de6d0be53e5ba263fe8eeb33c199a21f70004d83e06bbded76dc5f322/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 861,
+    "score": 871,
     "sections": [
       {
         "auto_collapse": false,
@@ -105,7 +105,31 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: [System.Convert]::FromBase64String(",
+        "body": "Marks: Text.Encoding, System.Convert",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 100,
+          "score_map": {
+            "Obfuscation": 100
+          },
+          "signatures": {
+            "Obfuscation": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Obfuscation",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: FromBase64String(",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -149,30 +173,6 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: One Liner",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 100,
-          "score_map": {
-            "Obfuscation:Char Frequency": 100
-          },
-          "signatures": {
-            "Obfuscation:Char Frequency": 1
-          }
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Signature: Obfuscation:Char Frequency",
         "zeroize_on_tag_safe": false
       },
       {
@@ -307,6 +307,30 @@
         "tags": {},
         "title_text": "Signature: Byte Usage",
         "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: IO.File",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Filesystem": 10
+          },
+          "signatures": {
+            "Filesystem": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Filesystem",
+        "zeroize_on_tag_safe": false
       }
     ]
   },
@@ -352,6 +376,13 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
+          "Obfuscation"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
           "Deobfuscation"
         ]
       },
@@ -360,13 +391,6 @@
         "heur_id": 3,
         "signatures": [
           "One Liner"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "Obfuscation:Char Frequency"
         ]
       },
       {
@@ -402,6 +426,13 @@
         "heur_id": 3,
         "signatures": [
           "Byte Usage"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Filesystem"
         ]
       },
       {

--- a/tests/results/c538472cd9af46f9f72ec09194aecada626acfde0506e07e3a872a6e95a8f0a2/result.json
+++ b/tests/results/c538472cd9af46f9f72ec09194aecada626acfde0506e07e3a872a6e95a8f0a2/result.json
@@ -110,7 +110,31 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: [Convert]::FromBase64String(",
+        "body": "Marks: Text.Encoding, UTF8.GetString",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 100,
+          "score_map": {
+            "Obfuscation": 100
+          },
+          "signatures": {
+            "Obfuscation": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Obfuscation",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: FromBase64String(",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -130,30 +154,6 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: Deobfuscation",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 100,
-          "score_map": {
-            "Obfuscation:Char Frequency": 100
-          },
-          "signatures": {
-            "Obfuscation:Char Frequency": 1
-          }
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Signature: Obfuscation:Char Frequency",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -199,14 +199,14 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "Deobfuscation"
+          "Obfuscation"
         ]
       },
       {
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "Obfuscation:Char Frequency"
+          "Deobfuscation"
         ]
       },
       {

--- a/tests/results/e1c40d86c558a003a1971480fac4cefc663efb5cddd9ac91104acc54e9150293/result.json
+++ b/tests/results/e1c40d86c558a003a1971480fac4cefc663efb5cddd9ac91104acc54e9150293/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1221,
+    "score": 1231,
     "sections": [
       {
         "auto_collapse": false,
@@ -99,7 +99,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: -bxor",
+        "body": "Marks: -bxor, System.Convert",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -123,7 +123,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: [System.Convert]::FromBase64String(",
+        "body": "Marks: FromBase64String(",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -167,6 +167,30 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: Byte Usage",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: Microsoft.Win32.UnsafeNativeMethods, Start-Job",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Evasion": 10
+          },
+          "signatures": {
+            "Evasion": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Evasion",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -237,6 +261,13 @@
         "heur_id": 3,
         "signatures": [
           "Byte Usage"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Evasion"
         ]
       },
       {

--- a/tests/results/f18a802525cde21f142da5ddd2b83c27dff4e4fdf6468ada2bf0b194fb477030/result.json
+++ b/tests/results/f18a802525cde21f142da5ddd2b83c27dff4e4fdf6468ada2bf0b194fb477030/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1572,
+    "score": 1682,
     "sections": [
       {
         "auto_collapse": false,
@@ -190,7 +190,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: Net.WebClient, DownloadFile",
+        "body": "Marks: WebClient, DownloadFile",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -286,7 +286,31 @@
       },
       {
         "auto_collapse": false,
-        "body": "Marks: [Convert]::FromBase64String(",
+        "body": "Marks: Text.Encoding",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 100,
+          "score_map": {
+            "Obfuscation": 100
+          },
+          "signatures": {
+            "Obfuscation": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Obfuscation",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: FromBase64String(",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -330,6 +354,30 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Signature: One Liner",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Marks: -ExecutionPolicy",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "Evasion": 10
+          },
+          "signatures": {
+            "Evasion": 1
+          }
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Signature: Evasion",
         "zeroize_on_tag_safe": false
       },
       {
@@ -475,6 +523,13 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
+          "Obfuscation"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
           "Deobfuscation"
         ]
       },
@@ -483,6 +538,13 @@
         "heur_id": 3,
         "signatures": [
           "One Liner"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "Evasion"
         ]
       },
       {

--- a/tools/ps1_profiler.py
+++ b/tools/ps1_profiler.py
@@ -116,6 +116,8 @@ def score_behaviours(behaviour_tags: Dict[str, Any]) -> Tuple[float, str, Dict[s
         "Ping": 1.0,
         "Mshta": 1.0,
         "Imports BitsTransfer": 1.0,
+        "Evasion": 1.0,
+        "Filesystem": 1.0,
         # Benign
         # Behaviours which are generally only seen in Benign scripts - subtracts from score.
         "Script Logging": -1.0,
@@ -359,21 +361,28 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
     ]
 
     behaviour_col["Downloader"] = [
-        ["Net.WebClient"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
+        ["WebClient"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
         ["DownloadFile"],
         ["DownloadString"],
         ["DownloadData"],
         ["WebProxy", "Net.CredentialCache"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
         ["Start-BitsTransfer"],
         ["bitsadmin"],
-        ["Sockets.TCPClient", "GetStream"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
+        ["TCPClient"],
         ["$env:LocalAppData"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
         ["Invoke-WebRequest"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
         ["Net.WebRequest"],
         ["wget"],
         # ["Get-Content"],
         ["send", "open", "responseBody"],
-        ["HttpWebRequest", "GetResponse"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
+        ["HttpWebRequest"],
         ["InternetExplorer.Application", "Navigate"],
         ["Excel.Workbooks.Open('http"],
         ["Notepad", "SendKeys", "ForEach-Object", "Clipboard", "http"],
@@ -381,6 +390,19 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
         ["iwr", "-outf"],
         # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3
         [". ", "mshta.exe", "http"],
+        # Inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
+        ["MSXML2.XMLH"],
+        ["Net.Sockets"],
+        ["Reverse TCP"],
+        ["GetSystemWebProxy"],
+        ["host"],
+        ["user-agent"],
+        ["Mozilla/4.0"],
+        ["PowerShellTcp"],
+        ["IPAddress"],
+        ["AcceptTcpClient"],
+        ["Invoke-RestMethod"],
+        ["-Uri"],
     ]
 
     behaviour_col["Starts Process"] = [
@@ -423,7 +445,8 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
     behaviour_col["Compression"] = [
         ["Convert", "FromBase64String", "Text.Encoding"],
         ["IO.Compression.GzipStream"],
-        ["Compression.CompressionMode]::Decompress"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L2
+        ["Compression.CompressionMode"],
         ["IO.Compression.DeflateStream"],
         ["IO.MemoryStream"],
     ]
@@ -436,6 +459,7 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
     ]
 
     behaviour_col["Custom Web Fields"] = [
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
         ["Headers.Add"],
         ["SessionKey", "SessiodID"],
         ["Method", "ContentType", "UserAgent", "WebRequest]::create"],
@@ -459,16 +483,25 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
 
     behaviour_col["Obfuscation"] = [
         ["-Join", "[int]", "-as", "[char]"],
+        # Supported by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L2
         ["-bxor"],
         ["PtrToStringAnsi"],
         ["[-1..-"],
         ["[array]::Reverse"],
         ["$ENV:COMSPEC\\..\\"],
+        # Inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L2
+        ["Text.Encoding"],
+        ["UTF8.GetString"],
+        ["System.Convert"],
+        ["EncodedCommand"],
+        # Inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L35
+        ["Text.AsciiEncoding"],
     ]
 
     behaviour_col["Deobfuscation"] = [
-        ["[Convert]::FromBase64String("],
-        ["[System.Convert]::FromBase64String("],
+        # Supported/inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L2
+        ["FromBase64String("],
+        ["FromHEXString("],
     ]
 
     behaviour_col["Crypto"] = [
@@ -595,6 +628,24 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
     behaviour_col["Mshta"] = [["mshta.exe"]]
 
     behaviour_col["Imports BitsTransfer"] = [["Import-Module", "BitsTransfer"]]
+
+    # Inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L15
+    behaviour_col["Evasion"] = [
+        ["Microsoft.Win32.UnsafeNativeMethods"],
+        ["Start-Job"],
+        ["-EP Bypass"],
+        ["-ExecutionPolicy"],
+    ]
+
+    # Inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Systems/Windows/powershell_code_patterns.json#L24
+    behaviour_col["Filesystem"] = [
+        ["env:APPDATA"],
+        ["Remove-Item"],
+        ["expand-archive"],
+        ["New-Item"],
+        ["WriteAllText"],
+        ["IO.File"],
+    ]
 
     # Behavioural Combos combine a base grouping of behaviours to help raise the score of files without a lot of complexity.
     # Take care in adding to this list and use a minimum length of 3 behaviours (or 2 really good ones!).

--- a/tools/ps1_profiler.py
+++ b/tools/ps1_profiler.py
@@ -335,7 +335,7 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
         ["Get-Random -count 16", "Win32_NetworkAdapterConfiguration", "whoami", "POST"],
         ["Get-Random -Minimum", "System.Buffer]::BlockCopy", "GetResponseStream()", "POST"],
         ["*.vbs", "*.lnk", "DllOpen", "DllCall"],
-        ["start-process  -WindowStyle hidden -FilePath taskkill.exe -ArgumentList"],
+        ["start-process", "-WindowStyle", "hidden", "-FilePath", "taskkill.exe", "-ArgumentList"],
         ["$xorkey", "xordData"],
         ["powershell_payloads"],
         ["attackcode"],
@@ -392,6 +392,12 @@ def profile_behaviours(behaviour_tags: Dict[str, any], original_data, alternativ
         ["WScript.Shell", "ActiveXObject", "run"],
         ["START", "$ENV:APPDATA", "exe", "http"],
         ["START", "rundll32"],
+        # Inspired by https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Modules/powershell_analyzer.py#L77
+        ["regsvr32 ", "C://", ".dll"],
+        ["regsvr32 ", "C:\\", ".dll"],
+        ["start ", ".exe)"],
+        ["CMD ", "/C ", "powershell"],
+        ["powershell ", "-exec ", "bypass ", "-c"],
     ]
 
     behaviour_col["Starts RunDll"] = [["START", "rundll32"]]


### PR DESCRIPTION
QuickScope uses behaviour combinations similar to what PS1Profiler does. It is worth integrating the missing ones into Overpower.

These regular expressions are useful for execution detection in PS1Profiler also:
https://github.com/CYB3RMX/Qu1cksc0pe/blob/086db196d2de289f0784ae4d8ee03f34bf10354b/Modules/powershell_analyzer.py#L77